### PR TITLE
Removes `Error` by propagating original `Stream/Sink` error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 [dependencies]
 futures = "0.1"
 bytes = "0.4"
-tokio-serde = "0.1"
+tokio-serde = "0.2"
 serde = "1.0"
 serde_json = "1.0"
 


### PR DESCRIPTION
Requires: https://github.com/carllerche/tokio-serde/pull/3