### PR TITLE
Make it compatible with the new tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tokio-serde-json"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,9 @@ JSON serialization and deserialization of frame values.
 [dependencies]
 futures = "0.1"
 bytes = "0.4"
-tokio-serde = "0.2"
+tokio-serde = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
-tokio-core = "0.1"
-tokio-io = "0.1"
+tokio = "0.1"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use `tokio-serde-json`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-serde-json = { git = "https://github.com/carllerche/tokio-serde-json" }
+tokio-serde-json = "0.2"
 ```
 
 Next, add this to your crate:

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,6 +1,5 @@
 extern crate futures;
-extern crate tokio_core;
-extern crate tokio_io;
+extern crate tokio;
 extern crate tokio_serde_json;
 
 #[macro_use]
@@ -8,39 +7,36 @@ extern crate serde_json;
 
 use futures::{Future, Sink};
 
-use tokio_core::reactor::Core;
-use tokio_core::net::TcpStream;
-
-// Use length delimited frames
-use tokio_io::codec::length_delimited;
+use tokio::{
+    codec::{FramedWrite, LengthDelimitedCodec},
+    net::TcpStream,
+};
 
 use tokio_serde_json::WriteJson;
 
 pub fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-
     // Bind a server socket
-    let socket = TcpStream::connect(
-        &"127.0.0.1:17653".parse().unwrap(),
-        &handle);
+    let socket = TcpStream::connect(&"127.0.0.1:17653".parse().unwrap());
 
-    core.run(socket.and_then(|socket| {
+    tokio::run(
+        socket
+            .and_then(|socket| {
+                // Delimit frames using a length header
+                let length_delimited = FramedWrite::new(socket, LengthDelimitedCodec::new());
 
-        // Delimit frames using a length header
-        let length_delimited = length_delimited::FramedWrite::new(socket);
+                // Serialize frames with JSON
+                let serialized = WriteJson::new(length_delimited);
 
-        // Serialize frames with JSON
-        let serialized = WriteJson::new(length_delimited);
-
-        // Send the value
-        serialized.send(json!({
-          "name": "John Doe",
-          "age": 43,
-          "phones": [
-            "+44 1234567",
-            "+44 2345678"
-          ]
-        }))
-    })).unwrap();
+                // Send the value
+                serialized
+                    .send(json!({
+                        "name": "John Doe",
+                        "age": 43,
+                        "phones": [
+                            "+44 1234567",
+                            "+44 2345678"
+                        ]
+                    })).map(|_| ())
+            }).map_err(|_| ()),
+    );
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,45 +1,42 @@
 extern crate futures;
-extern crate tokio_core;
-extern crate tokio_io;
-extern crate tokio_serde_json;
 extern crate serde_json;
+extern crate tokio;
+extern crate tokio_serde_json;
 
-use futures::Stream;
+use futures::{Future, Stream};
 
-use tokio_core::reactor::Core;
-use tokio_core::net::TcpListener;
-
-// Use length delimited frames
-use tokio_io::codec::length_delimited;
+use tokio::{
+    codec::{FramedRead, LengthDelimitedCodec},
+    net::TcpListener,
+};
 
 use serde_json::Value;
 use tokio_serde_json::ReadJson;
 
 pub fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-
     // Bind a server socket
-    let listener = TcpListener::bind(
-        &"127.0.0.1:17653".parse().unwrap(),
-        &handle).unwrap();
+    let listener = TcpListener::bind(&"127.0.0.1:17653".parse().unwrap()).unwrap();
 
     println!("listening on {:?}", listener.local_addr());
 
-    core.run(listener.incoming().for_each(|(socket, _)| {
-        // Delimit frames using a length header
-        let length_delimited = length_delimited::FramedRead::new(socket);
+    tokio::run(
+        listener
+            .incoming()
+            .for_each(|socket| {
+                // Delimit frames using a length header
+                let length_delimited = FramedRead::new(socket, LengthDelimitedCodec::new());
 
-        // Deserialize frames
-        let deserialized = ReadJson::<_, Value>::new(length_delimited)
-            .map_err(|e| println!("ERR: {:?}", e));
+                // Deserialize frames
+                let deserialized = ReadJson::<_, Value>::new(length_delimited)
+                    .map_err(|e| println!("ERR: {:?}", e));
 
-        // Spawn a task that prints all received messages to STDOUT
-        handle.spawn(deserialized.for_each(|msg| {
-            println!("GOT: {:?}", msg);
-            Ok(())
-        }));
+                // Spawn a task that prints all received messages to STDOUT
+                tokio::spawn(deserialized.for_each(|msg| {
+                    println!("GOT: {:?}", msg);
+                    Ok(())
+                }));
 
-        Ok(())
-    })).unwrap();
+                Ok(())
+            }).map_err(|_| ()),
+    );
 }


### PR DESCRIPTION
This pull request makes `tokio-serde-json` compatible with the new tokio.

This fixes: https://github.com/carllerche/tokio-serde-json/issues/15
And it requires the following pr to be merged and published: https://github.com/carllerche/tokio-serde/pull/4